### PR TITLE
docs: drop Nomad from the weekly deploy runbook

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md

--- a/how-to-deploy-weekly-femi-wiki-to-production.md
+++ b/how-to-deploy-weekly-femi-wiki-to-production.md
@@ -4,7 +4,7 @@
 
    ```sh
    # Use this script to get URLs of comparison pages (python required)
-   BRANCH=REL1_38
+   BRANCH=REL1_43
    EXTENSIONS='
      AchievementBadges
      DiscordRCFeed
@@ -20,10 +20,10 @@
    ```
 
 2. Release all extensions that has changes. Read [how-to-contribute-to-extensions.md#release] for details.
-3. Bump the extensions on [femiwiki/docker-mediawiki] repository. <!--([commit example](https://github.com/femiwiki/nomad/commit/))-->
+3. Bump the extensions on [femiwiki/docker-mediawiki] repository.
 4. Wait for a new docker image to be built. You can see the progress of the building process in the [Github workflow page].
-5. After building, copy a new latest docker image's tag from the [Github packages page].
-6. Edit [fastcgi.nomad] file and commit. If required, edit [http.nomad] too. ([commit example](https://github.com/femiwiki/docker-mediawiki/commit/68994922))
+5. After building, copy the new `femiwiki` image tag from the [Github packages page].
+6. Bump the `femiwiki` image tag (the `fastcgi` and `http` containers) in [infra/docker/container.tf] and commit.
 7. Wait that the Terraform run planned.
 8. Make sure that our database backup is stored well.
 9. Confirm the terraform apply.
@@ -31,6 +31,5 @@
 [how-to-contribute-to-extensions.md#release]: https://github.com/femiwiki/femiwiki/blob/main/how-to-contribute-to-extensions.md#release
 [femiwiki/docker-mediawiki]: https://github.com/femiwiki/docker-mediawiki
 [github workflow page]: https://github.com/femiwiki/docker-mediawiki/actions
-[github packages page]: https://github.com/orgs/femiwiki/packages/container/package/mediawiki
-[fastcgi.nomad]: https://github.com/femiwiki/nomad/blob/main/jobs/fastcgi.nomad
-[http.nomad]: https://github.com/femiwiki/nomad/blob/main/jobs/http.nomad
+[github packages page]: https://github.com/orgs/femiwiki/packages/container/package/femiwiki
+[infra/docker/container.tf]: https://github.com/femiwiki/infra/blob/main/docker/container.tf


### PR DESCRIPTION
## Why
We no longer use Nomad, but the weekly deploy runbook still told you to edit `fastcgi.nomad` / `http.nomad` in the (now unused) `femiwiki/nomad` repo. Production now runs on EC2 with containers managed by the Terraform docker provider (`infra/docker/container.tf`) + `compose.yml`.

## Changes
- **Step 6**: edit `*.nomad` jobs → bump the `femiwiki` image tag (`fastcgi` and `http` containers) in [infra/docker/container.tf], then `terraform apply` (steps 7/9, unchanged).
- **Step 5 / packages link**: `mediawiki` → `femiwiki` (the actually-deployed image, per container.tf).
- Removed the dead `femiwiki/nomad` link defs and the stale nomad commit-example comment.
- Refreshed the obviously stale `BRANCH=REL1_38` → `REL1_43`.

`CHANGELOG.md` keeps its dated 2021 Nomad migration entries as historical record (not misleading about the current state).

## Not touched (per decision)
The `module "nomad"` GitHub-repo resource + nomad label suite in `femiwiki/infra` are left as-is for now (removing them risks archiving/deleting the repo on apply).